### PR TITLE
Add multipart upload recovery 

### DIFF
--- a/feature/s3/manager/api.go
+++ b/feature/s3/manager/api.go
@@ -34,4 +34,6 @@ type UploadAPIClient interface {
 	CreateMultipartUpload(context.Context, *s3.CreateMultipartUploadInput, ...func(*s3.Options)) (*s3.CreateMultipartUploadOutput, error)
 	CompleteMultipartUpload(context.Context, *s3.CompleteMultipartUploadInput, ...func(*s3.Options)) (*s3.CompleteMultipartUploadOutput, error)
 	AbortMultipartUpload(context.Context, *s3.AbortMultipartUploadInput, ...func(*s3.Options)) (*s3.AbortMultipartUploadOutput, error)
+	ListMultipartUploads(ctx context.Context, params *s3.ListMultipartUploadsInput, optFns ...func(*s3.Options)) (*s3.ListMultipartUploadsOutput, error)
+	ListParts(ctx context.Context, params *s3.ListPartsInput, optFns ...func(*s3.Options)) (*s3.ListPartsOutput, error)
 }

--- a/feature/s3/manager/api.go
+++ b/feature/s3/manager/api.go
@@ -34,6 +34,5 @@ type UploadAPIClient interface {
 	CreateMultipartUpload(context.Context, *s3.CreateMultipartUploadInput, ...func(*s3.Options)) (*s3.CreateMultipartUploadOutput, error)
 	CompleteMultipartUpload(context.Context, *s3.CompleteMultipartUploadInput, ...func(*s3.Options)) (*s3.CompleteMultipartUploadOutput, error)
 	AbortMultipartUpload(context.Context, *s3.AbortMultipartUploadInput, ...func(*s3.Options)) (*s3.AbortMultipartUploadOutput, error)
-	ListMultipartUploads(ctx context.Context, params *s3.ListMultipartUploadsInput, optFns ...func(*s3.Options)) (*s3.ListMultipartUploadsOutput, error)
 	ListParts(ctx context.Context, params *s3.ListPartsInput, optFns ...func(*s3.Options)) (*s3.ListPartsOutput, error)
 }

--- a/feature/s3/manager/internal/testing/upload.go
+++ b/feature/s3/manager/internal/testing/upload.go
@@ -25,6 +25,8 @@ type UploadLoggingClient struct {
 	CreateMultipartUploadFn   func(*UploadLoggingClient, *s3.CreateMultipartUploadInput) (*s3.CreateMultipartUploadOutput, error)
 	CompleteMultipartUploadFn func(*UploadLoggingClient, *s3.CompleteMultipartUploadInput) (*s3.CompleteMultipartUploadOutput, error)
 	AbortMultipartUploadFn    func(*UploadLoggingClient, *s3.AbortMultipartUploadInput) (*s3.AbortMultipartUploadOutput, error)
+	ListMultipartUploadsFn    func(*UploadLoggingClient, *s3.ListMultipartUploadsInput) (*s3.ListMultipartUploadsOutput, error)
+	ListPartsFn               func(*UploadLoggingClient, *s3.ListPartsInput) (*s3.ListPartsOutput, error)
 
 	ignoredOperations []string
 
@@ -175,6 +177,42 @@ func (u *UploadLoggingClient) AbortMultipartUpload(ctx context.Context, params *
 	}
 
 	return &s3.AbortMultipartUploadOutput{}, nil
+}
+
+// ListMultipartUploads is the S3 ListMultipartUploads API.
+func (u *UploadLoggingClient) ListMultipartUploads(ctx context.Context, params *s3.ListMultipartUploadsInput, optFns ...func(*s3.Options)) (*s3.ListMultipartUploadsOutput, error) {
+	u.m.Lock()
+	defer u.m.Unlock()
+
+	u.traceOperation("ListMultipartUploads", params)
+	if err := u.simulateHTTPClientOption(optFns...); err != nil {
+		return nil, err
+	}
+
+	if u.AbortMultipartUploadFn != nil {
+		return u.ListMultipartUploadsFn(u, params)
+	}
+
+	// TODO: mock input
+	return &s3.ListMultipartUploadsOutput{}, nil
+}
+
+// ListParts is the S3 ListParts API.
+func (u *UploadLoggingClient) ListParts(ctx context.Context, params *s3.ListPartsInput, optFns ...func(*s3.Options)) (*s3.ListPartsOutput, error) {
+	u.m.Lock()
+	defer u.m.Unlock()
+
+	u.traceOperation("ListMultipartUploads", params)
+	if err := u.simulateHTTPClientOption(optFns...); err != nil {
+		return nil, err
+	}
+
+	if u.AbortMultipartUploadFn != nil {
+		return u.ListPartsFn(u, params)
+	}
+
+	// TODO: mock input
+	return &s3.ListPartsOutput{}, nil
 }
 
 // NewUploadLoggingClient returns a new UploadLoggingClient.

--- a/feature/s3/manager/internal/testing/upload.go
+++ b/feature/s3/manager/internal/testing/upload.go
@@ -193,7 +193,6 @@ func (u *UploadLoggingClient) ListMultipartUploads(ctx context.Context, params *
 		return u.ListMultipartUploadsFn(u, params)
 	}
 
-	// TODO: mock input
 	return &s3.ListMultipartUploadsOutput{}, nil
 }
 
@@ -211,7 +210,6 @@ func (u *UploadLoggingClient) ListParts(ctx context.Context, params *s3.ListPart
 		return u.ListPartsFn(u, params)
 	}
 
-	// TODO: mock input
 	return &s3.ListPartsOutput{}, nil
 }
 

--- a/feature/s3/manager/internal/testing/upload.go
+++ b/feature/s3/manager/internal/testing/upload.go
@@ -25,7 +25,6 @@ type UploadLoggingClient struct {
 	CreateMultipartUploadFn   func(*UploadLoggingClient, *s3.CreateMultipartUploadInput) (*s3.CreateMultipartUploadOutput, error)
 	CompleteMultipartUploadFn func(*UploadLoggingClient, *s3.CompleteMultipartUploadInput) (*s3.CompleteMultipartUploadOutput, error)
 	AbortMultipartUploadFn    func(*UploadLoggingClient, *s3.AbortMultipartUploadInput) (*s3.AbortMultipartUploadOutput, error)
-	ListMultipartUploadsFn    func(*UploadLoggingClient, *s3.ListMultipartUploadsInput) (*s3.ListMultipartUploadsOutput, error)
 	ListPartsFn               func(*UploadLoggingClient, *s3.ListPartsInput) (*s3.ListPartsOutput, error)
 
 	ignoredOperations []string
@@ -177,23 +176,6 @@ func (u *UploadLoggingClient) AbortMultipartUpload(ctx context.Context, params *
 	}
 
 	return &s3.AbortMultipartUploadOutput{}, nil
-}
-
-// ListMultipartUploads is the S3 ListMultipartUploads API.
-func (u *UploadLoggingClient) ListMultipartUploads(ctx context.Context, params *s3.ListMultipartUploadsInput, optFns ...func(*s3.Options)) (*s3.ListMultipartUploadsOutput, error) {
-	u.m.Lock()
-	defer u.m.Unlock()
-
-	u.traceOperation("ListMultipartUploads", params)
-	if err := u.simulateHTTPClientOption(optFns...); err != nil {
-		return nil, err
-	}
-
-	if u.AbortMultipartUploadFn != nil {
-		return u.ListMultipartUploadsFn(u, params)
-	}
-
-	return &s3.ListMultipartUploadsOutput{}, nil
 }
 
 // ListParts is the S3 ListParts API.

--- a/feature/s3/manager/upload.go
+++ b/feature/s3/manager/upload.go
@@ -154,8 +154,8 @@ type Uploader struct {
 	// Defaults to package const's MaxUploadParts value.
 	MaxUploadParts int32
 
-	// If an upload ID is provided the uploader will resume that upload ID
-	UploadID *string
+	// If an upload ID is found for a key the uploader will resume that upload ID
+	UploadIDsByKey map[string]string
 
 	// The client to use when uploading to S3.
 	S3 UploadAPIClient
@@ -484,11 +484,11 @@ func (u *multiuploader) upload(firstBuf io.ReadSeeker, cleanup func()) (*UploadO
 	var err error
 	var locationRecorder recordLocationClient
 	eTagByPartNumber := make(map[int32]string)
-	if u.cfg.UploadID != nil {
-		u.uploadID = *u.cfg.UploadID
+	if uploadID, hasUploadID := u.cfg.UploadIDsByKey[*u.in.Key]; hasUploadID {
+		u.uploadID = uploadID
 		params := &s3.ListPartsInput{}
 		awsutil.Copy(params, u.in)
-		params.UploadId = u.cfg.UploadID
+		params.UploadId = &uploadID
 		paginator := s3.NewListPartsPaginator(u.cfg.S3, params)
 		repeat := false
 		for paginator.HasMorePages() && !repeat {

--- a/feature/s3/manager/upload.go
+++ b/feature/s3/manager/upload.go
@@ -155,7 +155,7 @@ type Uploader struct {
 	MaxUploadParts int32
 
 	// If an upload ID is found for a key the uploader will resume that upload ID
-	UploadIDsByKey map[string]string
+	UploadIDsByBucketAndKey map[string]map[string]string
 
 	// The client to use when uploading to S3.
 	S3 UploadAPIClient
@@ -484,7 +484,7 @@ func (u *multiuploader) upload(firstBuf io.ReadSeeker, cleanup func()) (*UploadO
 	var err error
 	var locationRecorder recordLocationClient
 	eTagByPartNumber := make(map[int32]string)
-	if uploadID, hasUploadID := u.cfg.UploadIDsByKey[*u.in.Key]; hasUploadID {
+	if uploadID, hasUploadID := u.cfg.UploadIDsByBucketAndKey[*u.in.Bucket][*u.in.Key]; hasUploadID {
 		u.uploadID = uploadID
 		params := &s3.ListPartsInput{}
 		awsutil.Copy(params, u.in)

--- a/feature/s3/manager/upload.go
+++ b/feature/s3/manager/upload.go
@@ -490,12 +490,19 @@ func (u *multiuploader) upload(firstBuf io.ReadSeeker, cleanup func()) (*UploadO
 		awsutil.Copy(params, u.in)
 		params.UploadId = u.cfg.UploadID
 		paginator := s3.NewListPartsPaginator(u.cfg.S3, params)
-		for paginator.HasMorePages() {
+		repeat := false
+		for paginator.HasMorePages() && !repeat {
 			parts, err := paginator.NextPage(u.ctx, append(u.cfg.ClientOptions, locationRecorder.WrapClient())...)
 			if err != nil {
 				return nil, err
 			}
 			for _, part := range parts.Parts {
+				// HACK: currently the paginator will loop, paginating forever
+				// This logic stops the infinite loop when we see the same part again
+				// This can be removed when https://github.com/aws/aws-sdk-go-v2/issues/1140 is resolved
+				if _, repeat = eTagByPartNumber[part.PartNumber]; repeat {
+					break
+				}
 				eTag, err := strconv.Unquote(*part.ETag)
 				if err != nil {
 					return nil, err

--- a/feature/s3/manager/upload_test.go
+++ b/feature/s3/manager/upload_test.go
@@ -1008,10 +1008,11 @@ func TestAutomaticRecovery(tt *testing.T) {
 				UsePathStyle: true,
 			})
 
-			uploadId := "123"
 			uploader := manager.NewUploader(client, func(u *manager.Uploader) {
 				u.PartSize = int64(partSize)
-				u.UploadID = &uploadId
+				u.UploadIDsByKey = map[string]string{
+					"key": "123",
+				}
 			})
 
 			_, err = uploader.Upload(context.Background(), &s3.PutObjectInput{

--- a/feature/s3/manager/upload_test.go
+++ b/feature/s3/manager/upload_test.go
@@ -1010,8 +1010,8 @@ func TestAutomaticRecovery(tt *testing.T) {
 
 			uploader := manager.NewUploader(client, func(u *manager.Uploader) {
 				u.PartSize = int64(partSize)
-				u.UploadIDsByKey = map[string]string{
-					"key": "123",
+				u.UploadIDsByBucketAndKey = map[string]map[string]string{
+					"bucket": { "key": "123" },
 				}
 			})
 

--- a/feature/s3/manager/upload_test.go
+++ b/feature/s3/manager/upload_test.go
@@ -963,7 +963,7 @@ func TestUploadBufferStrategy(t *testing.T) {
 	}
 }
 
-func TestAutomaticRecovery(tt *testing.T) {
+func TestUploadRecovery(tt *testing.T) {
 	oneFailed := "upload multipart failed, upload id: 123, cause: checksum did not match for chunk 1, multipart upload out of sync with local file"
 	cases := map[string]struct {
 		parts         map[int32]string
@@ -1010,16 +1010,14 @@ func TestAutomaticRecovery(tt *testing.T) {
 
 			uploader := manager.NewUploader(client, func(u *manager.Uploader) {
 				u.PartSize = int64(partSize)
-				u.UploadIDsByBucketAndKey = map[string]map[string]string{
-					"bucket": { "key": "123" },
-				}
 			})
 
-			_, err = uploader.Upload(context.Background(), &s3.PutObjectInput{
+			uploadID := "123"
+			_, err = uploader.ResumeUpload(context.Background(), &s3.PutObjectInput{
 				Bucket: aws.String("bucket"),
 				Key:    aws.String("key"),
 				Body:   f,
-			})
+			}, &uploadID)
 
 			if err != nil && tCase.expectedError == nil {
 				t.Errorf("expected error to be nil but error was: %s", err)

--- a/service/s3/api_op_ListParts.go
+++ b/service/s3/api_op_ListParts.go
@@ -343,6 +343,12 @@ func (p *ListPartsPaginator) NextPage(ctx context.Context, optFns ...func(*Optio
 		p.nextToken = nil
 	}
 
+	// HACK (tmorse): this code is auto-generated so this manual block shouldn't be added but there is a pretty
+	// major bug that causes this paginator to loop forever.
+	if p.nextToken != nil && *p.nextToken == "0" {
+		p.nextToken = nil
+	}
+
 	return result, nil
 }
 

--- a/service/s3/api_op_ListParts.go
+++ b/service/s3/api_op_ListParts.go
@@ -343,12 +343,6 @@ func (p *ListPartsPaginator) NextPage(ctx context.Context, optFns ...func(*Optio
 		p.nextToken = nil
 	}
 
-	// HACK (tmorse): this code is auto-generated so this manual block shouldn't be added but there is a pretty
-	// major bug that causes this paginator to loop forever.
-	if p.nextToken != nil && *p.nextToken == "0" {
-		p.nextToken = nil
-	}
-
 	return result, nil
 }
 


### PR DESCRIPTION
Very willing to change this with any feedback. Adds a new method called  `ResumeUpload` to the `Uploader` struct. This method adds an `existingUploadID` to the underlying `uploader` struct and both it and `Upload` call the same underlying private method with the `uploader`. The existing upload logic is modified so if an `existingUploadID` is present it doesn't create a new multipart upload and it builds a map of part numbers to ETags for all of the already uploaded parts for that upload. During the upload itself, if a chunk is in this map, instead of being uploaded its md5 checksum is computed and that is compared with the ETag. This is to ensure the file hasn't changed between uploads, which could result in corruption. It also handles the case of different part sizes since they will have different checksums, though it may be more user-friendly to handle this explicitly.

Originally I wanted to add this logic as an option in the existing `Upload` function but all of those options are options that can be global to the `Uploader` so any way I tried to do it would have been confusing as weird. Here's some example usage of the new method:

```go
uploader.ResumeUpload(input, uploadID)
```

Suggestion for: https://github.com/aws/aws-sdk-go-v2/issues/1145